### PR TITLE
fixed transmission loading

### DIFF
--- a/ros_ethercat_model/include/ros_ethercat_model/robot_state.hpp
+++ b/ros_ethercat_model/include/ros_ethercat_model/robot_state.hpp
@@ -107,12 +107,12 @@ public:
              it != t->joint_names_.end();
              ++it)
         {
-          JointState *jnt = getJointState(*it);
-          if (!jnt)
+          if (!robot_model_.getJoint(*it))
             throw std::runtime_error(std::string("Couldn't find joint named: ") +
-                                     type +
-                                     " in robot model transmission's");
+                                     *it +
+                                     " in robot model transmission's " + t->name_);
           joint_states_[*it].joint_ = robot_model_.getJoint(*it);
+          JointState *jnt = getJointState(*it);
           stats.push_back(jnt);
         }
         transmissions_out_.push_back(stats);


### PR DESCRIPTION
fixed transmission loading to check for joint existence in robot model not in local map
fixed error message to display joint name and transmission name not transmission type
