### PR TITLE
Fix wait for calibration problem. 

### DIFF
--- a/ros_ethercat_model/scripts/ros_ethercat_model/calibrate
+++ b/ros_ethercat_model/scripts/ros_ethercat_model/calibrate
@@ -74,7 +74,7 @@ def calibrate(controllers):
         def calibrated(msg, name):  # Somewhat not thread-safe
             if name in waiting_for:
                 waiting_for.remove(name)
-        for name in waiting_for:
+        for name in launched:
             rospy.Subscriber("%s/calibrated" % name, Empty, calibrated, name)
 
         # Waits until all the controllers have calibrated


### PR DESCRIPTION
It was iterating through a list while elements were being removed by another thread.
The effect was that, depending on the timing, sometimes the script never subscribed to a calibration controller, and stayed waiting forever for the calibration to finish.

Long explanation for a such a short PR.
