### PR TITLE
use boost/std-agnostic shared_ptrs for urdf types

### DIFF
--- a/ros_ethercat_model/include/ros_ethercat_model/joint.hpp
+++ b/ros_ethercat_model/include/ros_ethercat_model/joint.hpp
@@ -144,7 +144,7 @@ public:
   }
 
   /// A pointer to the corresponding urdf::Joint from the urdf::Model
-  boost::shared_ptr<const urdf::Joint> joint_;
+  urdf::JointConstSharedPtr joint_;
 
   /// The joint position in radians or meters (read-only variable)
   double position_;

--- a/ros_ethercat_model/include/ros_ethercat_model/robot_state.hpp
+++ b/ros_ethercat_model/include/ros_ethercat_model/robot_state.hpp
@@ -89,7 +89,7 @@ public:
     {
       if (!robot_model_.initXml(root))
         throw std::runtime_error("Failed to load robot_model_");
-      for (std::map<std::string, boost::shared_ptr<urdf::Joint> >::const_iterator it = robot_model_.joints_.begin();
+      for (std::map<std::string, urdf::JointSharedPtr>::const_iterator it = robot_model_.joints_.begin();
            it != robot_model_.joints_.end();
            ++it)
       {


### PR DESCRIPTION
needed for bionic build, and is backward compatible with kinetic (since it is boost/std-agnostic)