### PR TITLE
remove args that are stated as useless by ROS

### DIFF
--- a/ros_ethercat_model/launch/joint_state_publisher.launch
+++ b/ros_ethercat_model/launch/joint_state_publisher.launch
@@ -4,5 +4,5 @@
   <rosparam command="load" file="$(find ros_ethercat_model)/launch/joint_state_controller.yaml" />
   <param name="joint_state_controller/publish_rate" value="$(arg publish_rate)"/>
   <!-- spawn controller -->
-  <node name="joint_state_controller_spawner" pkg="controller_manager" type="spawner" output="screen" args="--shutdown-timeout=1.0 joint_state_controller" />
+  <node name="joint_state_controller_spawner" pkg="controller_manager" type="spawner" output="screen" args="joint_state_controller" />
 </launch>


### PR DESCRIPTION
## Proposed changes
When running simulation or real hardware, a warning message pops up stating that the --shutdown argument is now deprecated and will not be used. So removed it in the joint publisher to avoif having warning messages.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

Put an x in the boxes that apply. You can also fill these out after creating the PR. This is a reminder of what we should look for before merging this code. I have:

- [x] Read and follow the [contributing guidelines](https://github.com/shadow-robot/sr_documentation/blob/master/CONTRIBUTING.md).
- [ ] Checked that all tests pass with my changes
- [ ] Added tests (automatic or manual) that prove the fix is effective or that the feature works
- [ ] Added necessary documentation (if appropriate)
- [ ] Added the corresponding license to each file and add the current year of any one that you modified.
- [ ] Tested on real hardware (if appropriate)
