### PR TITLE
remove obsolete scoped_ptr

### DIFF
--- a/ros_ethercat_hardware/src/ethercat_hardware.cpp
+++ b/ros_ethercat_hardware/src/ethercat_hardware.cpp
@@ -42,6 +42,7 @@
 #include <boost/foreach.hpp>
 #include <boost/regex.hpp>
 #include <string>
+#include <memory>
 
 EthercatHardwareDiagnostics::EthercatHardwareDiagnostics() :
   txandrx_errors_(0),
@@ -188,8 +189,8 @@ std::vector<EtherCAT_SlaveHandler> EthercatHardware::scanPort(const std::string&
   EC_Logic logic_instance;
   EtherCAT_DataLinkLayer dll_instance;
   EtherCAT_PD_Buffer pd_buffer(&logic_instance, &dll_instance);
-  boost::scoped_ptr<EtherCAT_AL> application_layer;
-  boost::scoped_ptr<EtherCAT_Router> router;
+  std::unique_ptr<EtherCAT_AL> application_layer;
+  std::unique_ptr<EtherCAT_Router> router;
 
   dll_instance.attach(ni);
   application_layer.reset(new EtherCAT_AL(&dll_instance, &logic_instance, &pd_buffer));

--- a/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
+++ b/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
@@ -42,6 +42,7 @@
 
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <memory>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/thread/thread.hpp>
@@ -379,7 +380,7 @@ public:
   string eth_;
   boost::shared_ptr<ros_ethercat_model::RobotState> model_;
   ptr_vector<EthercatHardware> ethercat_hardware_;
-  boost::scoped_ptr<MechStatsPublisher> mech_stats_publisher_;
+  std::unique_ptr<MechStatsPublisher> mech_stats_publisher_;
 
   // robot state interface
   ros_ethercat_model::RobotStateInterface robot_state_interface_;


### PR DESCRIPTION
in favor of c++11 unique_ptr

Compiling packages for the ros-o initiative, this package broke because scoped_ptr was not found anymore.