### PR TITLE
Multi-threaded ethercat device updates (for bimanual systems)

### DIFF
--- a/ros_ethercat_hardware/include/ros_ethercat_hardware/ethercat_hardware.h
+++ b/ros_ethercat_hardware/include/ros_ethercat_hardware/ethercat_hardware.h
@@ -259,6 +259,12 @@ public:
 
   hardware_interface::HardwareInterface *hw_;
 
+  boost::mutex update_mutex;  //!< mutex that protects all class data updates
+  boost::condition_variable start_of_work_condition_eth_hw_read;
+  boost::condition_variable end_of_work_condition_eth_hw_read;
+  std::atomic<bool> can_run_eth_hw_read_;
+  std::atomic<bool> eth_hw_read_done_;
+
   const std::vector<boost::shared_ptr<const EthercatDevice> > getSlaves() const
   {
     return std::vector<boost::shared_ptr<const EthercatDevice> >(slaves_.begin(), slaves_.end());

--- a/ros_ethercat_hardware/include/ros_ethercat_hardware/ethercat_hardware.h
+++ b/ros_ethercat_hardware/include/ros_ethercat_hardware/ethercat_hardware.h
@@ -259,7 +259,8 @@ public:
 
   hardware_interface::HardwareInterface *hw_;
 
-  boost::mutex update_mutex;  //!< mutex that protects all class data updates
+  // Attributes required to run multi-threaded calls to HardwareInterface.update (for multiple HardwareInterface's)
+  boost::mutex update_mutex;
   boost::condition_variable start_of_work_condition_eth_hw_read;
   boost::condition_variable end_of_work_condition_eth_hw_read;
   std::atomic<bool> can_run_eth_hw_read_;

--- a/ros_ethercat_hardware/src/ethercat_hardware.cpp
+++ b/ros_ethercat_hardware/src/ethercat_hardware.cpp
@@ -532,7 +532,7 @@ void EthercatHardwareDiagnosticsPublisher::publishDiagnostics()
   status_.clearSummary();
   status_.clear();
 
-  status_.name = "EtherCAT Master";
+  status_.name = "EtherCAT Port " + interface_;
 //  if (diagnostics_.motors_halted_)
 //  {
 //    std::ostringstream desc;

--- a/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
+++ b/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
@@ -6,7 +6,7 @@
 *
 * Software License Agreement (BSD License)
 *
-*  Copyright (c) 2014, Shadow Robot Company Ltd.
+*  Copyright (c) 2014, 2024 Shadow Robot Company Ltd.
 *  All rights reserved.
 *
 *  Redistribution and use in source and binary forms, with or without
@@ -182,50 +182,27 @@ public:
     }
   }
 
-  void displayAndChange(boost::thread& daThread)
+  bool updateThreadPriority(boost::thread& a_thread)
   {
-      int retcode;
-      int policy;
+    int retcode;
+    int policy;
+    struct sched_param param;
 
-      pthread_t threadID = (pthread_t) daThread.native_handle();
+    pthread_t threadID = (pthread_t) a_thread.native_handle();
 
-      struct sched_param param;
+    policy = SCHED_FIFO;
+    param.sched_priority = sched_get_priority_max(policy);
 
-      if ((retcode = pthread_getschedparam(threadID, &policy, &param)) != 0)
-      {
-          errno = retcode;
-          perror("pthread_getschedparam");
-          exit(EXIT_FAILURE);
-      }
-
-      std::cout << "INHERITED: ";
-      std::cout << "policy=" << ((policy == SCHED_FIFO)  ? "SCHED_FIFO" :
-                                (policy == SCHED_RR)    ? "SCHED_RR" :
-                                (policy == SCHED_OTHER) ? "SCHED_OTHER" :
-                                                          "???")
-                << ", priority=" << param.sched_priority << std::endl;
-
-
-      policy = SCHED_FIFO;
-      param.sched_priority = 4;
-
-      if ((retcode = pthread_setschedparam(threadID, policy, &param)) != 0)
-      {
-          errno = retcode;
-          perror("pthread_setschedparam");
-          exit(EXIT_FAILURE);
-      }
-
-      std::cout << "  CHANGED: ";
-      std::cout << "policy=" << ((policy == SCHED_FIFO)  ? "SCHED_FIFO" :
-                                (policy == SCHED_RR)    ? "SCHED_RR" :
-                                (policy == SCHED_OTHER) ? "SCHED_OTHER" :
-                                                            "???")
-                << ", priority=" << param.sched_priority << std::endl;
+    if ((retcode = pthread_setschedparam(threadID, policy, &param)) != 0)
+    {
+      ROS_ERROR("Error setting policy/priority of Ethercat hardware threads. Please restart the system");
+      return false;
+    }
+    return true;
   }
 
 
-  void test(EthercatHardware * eh)
+  void ethercat_update_thread(EthercatHardware * eh)
   {
     while (true)
     {
@@ -372,19 +349,25 @@ public:
     // but until we remove the compatibility mode this will do.
     collect_diagnostics_thread_ = boost::thread(&RosEthercat::collect_diagnostics_loop, this);
 
-    hardware_update_thread_.reserve(ethercat_hardware_.size());
-
-    for (ptr_vector<EthercatHardware>::iterator eh = ethercat_hardware_.begin();
-         eh != ethercat_hardware_.end();
-         ++eh)
+    if (ethercat_hardware_.size() > 1)
     {
-      EthercatHardware* current_eth = &(*eh);
-      current_eth->can_run_eth_hw_read_.store(false);
-      current_eth->eth_hw_read_done_.store(false);
+      hardware_update_thread_.reserve(ethercat_hardware_.size());
 
-      auto functor = boost::bind(&RosEthercat::test, this, current_eth);
-      hardware_update_thread_.push_back(new boost::thread(functor));
-      displayAndChange(*hardware_update_thread_.back());
+      for (ptr_vector<EthercatHardware>::iterator eh = ethercat_hardware_.begin();
+          eh != ethercat_hardware_.end();
+          ++eh)
+      {
+        EthercatHardware* current_eth = &(*eh);
+        current_eth->can_run_eth_hw_read_.store(false);
+        current_eth->eth_hw_read_done_.store(false);
+
+        auto functor = boost::bind(&RosEthercat::ethercat_update_thread, this, current_eth);
+        hardware_update_thread_.push_back(new boost::thread(functor));
+        if (!updateThreadPriority(*hardware_update_thread_.back()))
+        {
+          return false;
+        }
+      }
     }
 
     return true;
@@ -393,27 +376,34 @@ public:
   /// propagate position actuator -> joint and set commands to zero
   void read(const ros::Time &time, const ros::Duration& period)
   {
-    for (ptr_vector<EthercatHardware>::iterator eh = ethercat_hardware_.begin();
-         eh != ethercat_hardware_.end();
-         ++eh)
+    if (ethercat_hardware_.size() == 1)
     {
-      {
-        boost::lock_guard<boost::mutex> lock(eh->update_mutex);
-        eh->can_run_eth_hw_read_.store(true);
-        eh->eth_hw_read_done_.store(false);
-      }
-      eh->start_of_work_condition_eth_hw_read.notify_one();
+      ethercat_hardware_[0].update(false, false);
     }
-
-    for (ptr_vector<EthercatHardware>::iterator eh = ethercat_hardware_.begin();
-         eh != ethercat_hardware_.end();
-         ++eh)
+    else
     {
+      for (ptr_vector<EthercatHardware>::iterator eh = ethercat_hardware_.begin();
+          eh != ethercat_hardware_.end();
+          ++eh)
       {
-        boost::unique_lock<boost::mutex> lock(eh->update_mutex);
-        while(!eh->eth_hw_read_done_.load())
         {
-          eh->end_of_work_condition_eth_hw_read.wait(lock);
+          boost::lock_guard<boost::mutex> lock(eh->update_mutex);
+          eh->can_run_eth_hw_read_.store(true);
+          eh->eth_hw_read_done_.store(false);
+        }
+        eh->start_of_work_condition_eth_hw_read.notify_one();
+      }
+
+      for (ptr_vector<EthercatHardware>::iterator eh = ethercat_hardware_.begin();
+          eh != ethercat_hardware_.end();
+          ++eh)
+      {
+        {
+          boost::unique_lock<boost::mutex> lock(eh->update_mutex);
+          while(!eh->eth_hw_read_done_.load())
+          {
+            eh->end_of_work_condition_eth_hw_read.wait(lock);
+          }
         }
       }
     }
@@ -479,11 +469,13 @@ public:
       eh->update(false, true);
     }
 
-    for (uint8_t hardware_index = 0;
-      hardware_index < ethercat_hardware_.size();
-      ++hardware_index)
+    if (ethercat_hardware_.size() > 1)
     {
-      delete hardware_update_thread_[hardware_index];
+      for (uint8_t hardware_index = 0; hardware_index < ethercat_hardware_.size();
+        ++hardware_index)
+      {
+        delete hardware_update_thread_[hardware_index];
+      }
     }
   }
 

--- a/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
+++ b/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
@@ -202,7 +202,7 @@ public:
     return true;
   }
 
-  /// Thread that calls EthercatHardware.update 
+  /// Thread that calls EthercatHardware.update
   void ethercat_update_thread(EthercatHardware * eh)
   {
     while (true)

--- a/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
+++ b/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
@@ -350,7 +350,7 @@ public:
     // but until we remove the compatibility mode this will do.
     collect_diagnostics_thread_ = boost::thread(&RosEthercat::collect_diagnostics_loop, this);
 
-    // If we are running more than one ethercat hardware, spin up multiple threads 
+    // If we are running more than one ethercat hardware, spin up multiple threads
     if (ethercat_hardware_.size() > 1)
     {
       hardware_update_thread_.reserve(ethercat_hardware_.size());

--- a/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
+++ b/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
@@ -182,6 +182,7 @@ public:
     }
   }
 
+  /// Update priority of provided thread
   bool updateThreadPriority(boost::thread& a_thread)
   {
     int retcode;
@@ -201,7 +202,7 @@ public:
     return true;
   }
 
-
+  /// Thread that calls EthercatHardware.update 
   void ethercat_update_thread(EthercatHardware * eh)
   {
     while (true)
@@ -349,6 +350,7 @@ public:
     // but until we remove the compatibility mode this will do.
     collect_diagnostics_thread_ = boost::thread(&RosEthercat::collect_diagnostics_loop, this);
 
+    // If we are running more than one ethercat hardware, spin up multiple threads 
     if (ethercat_hardware_.size() > 1)
     {
       hardware_update_thread_.reserve(ethercat_hardware_.size());
@@ -380,6 +382,7 @@ public:
     {
       ethercat_hardware_[0].update(false, false);
     }
+    // If we are running multiple Ethercat devices, parallelise calls to EthercatHardware.update
     else
     {
       for (ptr_vector<EthercatHardware>::iterator eh = ethercat_hardware_.begin();
@@ -400,7 +403,7 @@ public:
       {
         {
           boost::unique_lock<boost::mutex> lock(eh->update_mutex);
-          while(!eh->eth_hw_read_done_.load())
+          while (!eh->eth_hw_read_done_.load())
           {
             eh->end_of_work_condition_eth_hw_read.wait(lock);
           }

--- a/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
+++ b/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
@@ -185,7 +185,6 @@ public:
   /// Update priority of provided thread
   bool updateThreadPriority(boost::thread& a_thread)
   {
-    int retcode;
     int policy;
     struct sched_param param;
 
@@ -194,7 +193,7 @@ public:
     policy = SCHED_FIFO;
     param.sched_priority = sched_get_priority_max(policy);
 
-    if ((retcode = pthread_setschedparam(threadID, policy, &param)) != 0)
+    if (pthread_setschedparam(threadID, policy, &param) != 0)
     {
       ROS_ERROR("Error setting policy/priority of Ethercat hardware threads. Please restart the system");
       return false;


### PR DESCRIPTION
## Proposed changes

Launch multiple threads to invoke parallel calls to 'update' of each detected ethercat device (i.e. when running a bimanual system).
This is particularly necessary necessary when the Shadow Hands' are installed with the latest FW 250 (STF support) due to tighter ethercat communication time constraints (thus making it more sensitive to jitters) - [SRC-7344](https://shadowrobot.atlassian.net/browse/SRC-7344)

If only one hand is detected, the code should run as before (i.e. no threads are started), to avoid any unnecessary computing overheads. 

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [x] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).


[SRC-7344]: https://shadowrobot.atlassian.net/browse/SRC-7344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ