### PR TITLE
Reduce priority of threaded ethercat device updates

### DIFF
--- a/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
+++ b/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
@@ -182,10 +182,7 @@ public:
 
         auto functor = boost::bind(&RosEthercat::ethercat_update_thread, this, current_eth);
         hardware_update_thread_.push_back(new boost::thread(functor));
-        if (!updateThreadPriority(*hardware_update_thread_.back()))
-        {
-          return false;
-        }
+        updateThreadPriority(*hardware_update_thread_.back());
       }
     }
   }

--- a/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
+++ b/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
@@ -191,7 +191,7 @@ public:
     pthread_t threadID = (pthread_t) a_thread.native_handle();
 
     policy = SCHED_FIFO;
-    param.sched_priority = sched_get_priority_max(policy);
+    param.sched_priority = sched_get_priority_max(policy) - 1;
 
     if (pthread_setschedparam(threadID, policy, &param) != 0)
     {

--- a/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
+++ b/ros_ethercat_model/include/ros_ethercat_model/ros_ethercat.hpp
@@ -162,6 +162,32 @@ public:
     registerInterface(&joint_velocity_command_interface_);
     registerInterface(&joint_effort_command_interface_);
     registerInterface(&imu_sensor_interface_);
+
+    // Start a thread to collect diagnostics. This could actually be inside the EthercatHardware class
+    // but until we remove the compatibility mode this will do.
+    collect_diagnostics_thread_ = boost::thread(&RosEthercat::collect_diagnostics_loop, this);
+
+    // If we are running more than one ethercat hardware, spin up multiple threads
+    if (ethercat_hardware_.size() > 1)
+    {
+      hardware_update_thread_.reserve(ethercat_hardware_.size());
+
+      for (ptr_vector<EthercatHardware>::iterator eh = ethercat_hardware_.begin();
+          eh != ethercat_hardware_.end();
+          ++eh)
+      {
+        EthercatHardware* current_eth = &(*eh);
+        current_eth->can_run_eth_hw_read_.store(false);
+        current_eth->eth_hw_read_done_.store(false);
+
+        auto functor = boost::bind(&RosEthercat::ethercat_update_thread, this, current_eth);
+        hardware_update_thread_.push_back(new boost::thread(functor));
+        if (!updateThreadPriority(*hardware_update_thread_.back()))
+        {
+          return false;
+        }
+      }
+    }
   }
 
   virtual ~RosEthercat()


### PR DESCRIPTION
## Proposed changes

The parent process should have a higher priority over the children threads, so that during the "posting" of the task it never gets interrupted by the first child thread

Update the constructer of RosEthercat to also include a multithreaded call to EthercatHardware updates.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [x] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
