### PR TITLE
Change urdf parser to skip transmissions defined with type 'UnusedTra…

### DIFF
--- a/ros_ethercat_model/include/ros_ethercat_model/robot_state.hpp
+++ b/ros_ethercat_model/include/ros_ethercat_model/robot_state.hpp
@@ -122,6 +122,14 @@ public:
     type = std::string(xit->FirstChildElement("type")->GetText());
   }
 
+  // Real Dex-EE does not use transmissions, so we declare a dummy transmission type to skip the
+  // instantiation of the transmission.
+  // However, DEX-EE Gazebo simulation requires the 'joint' elements from the transmission, which is
+  // why we keep the transmissions in the urdf.
+  if (type == "UnusedTransmission")
+  {
+    continue;
+  }
   joint_name = string(xit->FirstChildElement("joint")->Attribute("name"));
   if (joint_name.empty())
   {
@@ -140,7 +148,7 @@ public:
     }
     catch (const std::runtime_error &ex)
     {
-      ROS_WARN_STREAM("ros_ethercat_model failed to parse the URDF xml into a robot model\n" << ex.what());
+      ROS_FATAL_STREAM("ros_ethercat_model failed to parse the URDF xml into a robot model\n" << ex.what());
     }
   }
 


### PR DESCRIPTION
Change urdf parser to skip transmissions defined with type 'UnusedTransmission' (reflecting the changes from https://github.com/shadow-robot/rh_host/pull/277)
Real Dex-EE does not use transmissions, so we declare a dummy transmission type to skip the instantiation of the transmission.
However, DEX-EE Gazebo simulation requires the 'joint' elements from the transmission, which is why we keep the transmissions in the urdf.

## Proposed changes

Please explain the changes you made. Add pictures or videos to explain them better if appropriate.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [x] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
